### PR TITLE
Converting CIDR to plain IP for last message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,5 +52,8 @@ pct exec $number -- bash -c 'curl -s -S -L https://raw.githubusercontent.com/Adg
 # Reboot the container
 pct exec $number -- reboot
 
+# Covert CIRD to plain IP
+plain_ip="${ip%%/*}"
+
 # Final message
-echo "You can now browse to http://$ip:3000 to resume the rest of the configuration."
+echo "You can now browse to http://$plain_ip:3000 to resume the rest of the configuration."


### PR DESCRIPTION
Great script, thanks for making it! Just used it without issues on my Proxmox instance.

I did notice the last message didn't quite link me to the correct URL as it was using the CIDR address:

<img width="892" alt="image" src="https://github.com/morfeus02/Adguard-Proxmox/assets/64991745/88173d47-c58f-4e57-9f4e-0f8216b37cc3">
